### PR TITLE
dago/a11y-search

### DIFF
--- a/routes/failai.js
+++ b/routes/failai.js
@@ -385,7 +385,7 @@ failaiSearchRouter.get(
         } catch {
             total = 10_000;
             const trukme = ((performance.now() - startas) / 1000).toFixed(2);
-            numberOfResults = `Rodomi ${results.length} iš <span class="rezultatai-nezinomas-total"> ? </span> rezultatų <pre data-duration="${trukme}" class="inline"> (${trukme}s, ${engine})</pre>`;
+            numberOfResults = `Rodomi ${results.length} iš <span class="rezultatai-nezinomas-total"> ? </span> rezultatų <span data-duration="${trukme}" class="inline"> (${trukme}s, ${engine})</span>`;
         }
 
         if (req.query.json)

--- a/styles/forms.css
+++ b/styles/forms.css
@@ -3,7 +3,7 @@
         @apply mb-4;
     }
 
-    fieldset > .form-group {
+    fieldset.filter-group > .form-group {
         @apply mb-0;
     }
 

--- a/styles/forms.css
+++ b/styles/forms.css
@@ -1,5 +1,13 @@
 @layer components {
-    .form-group { margin-bottom: var(--space-4); }
+    .form-group {
+        @apply mb-4;
+    }
+
+    fieldset > .form-group {
+        @apply mb-0;
+    }
+
+
     .form-row   { display: grid; grid-template-columns: repeat(2, 1fr); gap: var(--space-4); }
 
     @media (max-width: 600px) {
@@ -218,9 +226,7 @@
     .form-switch input:checked + .switch-track::before { transform: translateX(18px); }
 
     .search-filters-grid {
-        display: grid;
-        grid-template-columns: repeat(4, 1fr);
-        gap: var(--space-3);
+        @apply grid grid-cols-4 gap-x-4 gap-y-8;
     }
 
     .filter-group {
@@ -248,13 +254,15 @@
         gap: var(--space-3);
     }
 
+    fieldset.filter-group {
+        border: none;
+        padding: 0;
+        margin: 0;
+        min-width: 0;
+    }
+
     .filter-group-label {
-        font-size: var(--text-xs);
-        font-weight: 700;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: var(--gray);
-        margin-bottom: var(--space-1);
+        @apply text-xs font-bold uppercase text-gray mb-2;
     }
 
     .btn-icon {
@@ -263,6 +271,11 @@
         justify-content: center;
         padding: var(--space-2);
         cursor: pointer;
+    }
+
+    .btn-icon:focus-within {
+        outline: 2px solid currentColor;
+        outline-offset: 2px;
     }
 
     #searchForm {
@@ -295,7 +308,7 @@
         border-radius: var(--radius-md);
     }
 
-    #searchNustatymaiToggle:checked ~ .search-filters {
+    #searchForm:has(#searchNustatymaiToggle:checked) .search-filters {
         height: auto;
         box-shadow: 0 0 0 1px var(--light-gray);
     }

--- a/views/failai/results.ejs
+++ b/views/failai/results.ejs
@@ -66,7 +66,7 @@
         span.classList.add('spin');
         const url = new URL(window.location.href);
         url.searchParams.set('rezultatuSkaiciausPatikslinimas', 'true');
-        const trukme = document.querySelector('.numberOfResults pre')?.getAttribute('data-duration');
+        const trukme = document.querySelector('.numberOfResults span')?.getAttribute('data-duration');
         if (trukme) url.searchParams.set('trukme', trukme);
         fetch(url)
           .then(res => res.json())

--- a/views/failai/search.ejs
+++ b/views/failai/search.ejs
@@ -16,7 +16,8 @@
       enterkeyhint="search"
     />
 
-    <label for="searchNustatymaiToggle" class="btn btn-ghost btn-icon" title="Filtrai" aria-label="Rodyti filtrus">
+    <label class="btn btn-ghost btn-icon" title="Filtrai" aria-label="<%= usedHiddenFields ? 'Slėpti filtrus' : 'Rodyti filtrus' %>" aria-expanded="<%= usedHiddenFields ? 'true' : 'false' %>" aria-controls="searchNustatymai">
+      <input type="checkbox" id="searchNustatymaiToggle" class="sr-only" <% if (usedHiddenFields) { %>checked<% } %>>
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path fill-rule="evenodd" clip-rule="evenodd" d="M11.9999 3C11.4476 3 10.9999 3.44772 10.9999 4V6.17072C9.83476 6.58259 9 7.6938 9 8.99998C9 10.3062 9.83476 11.4174 10.9999 11.8292L10.9999 20C10.9999 20.5523 11.4476 21 11.9999 21C12.5522 21 12.9999 20.5523 12.9999 20V11.8293C14.1651 11.4175 15 10.3062 15 8.99998C15 7.69373 14.1651 6.58246 12.9999 6.17066V4C12.9999 3.44772 12.5522 3 11.9999 3ZM12 7.99998C11.4477 7.99998 11 8.4477 11 8.99998C11 9.55227 11.4477 9.99998 12 9.99998C12.5523 9.99998 13 9.55227 13 8.99998C13 8.4477 12.5523 7.99998 12 7.99998Z" fill="currentColor"/>
         <path fill-rule="evenodd" clip-rule="evenodd" d="M17.9999 20C17.9999 20.5523 18.4476 21 18.9999 21C19.5522 21 19.9999 20.5523 19.9999 20V17.8293C21.1651 17.4175 22 16.3062 22 15C22 13.6937 21.1651 12.5825 19.9999 12.1707V4C19.9999 3.44772 19.5522 3 18.9999 3C18.4476 3 17.9999 3.44772 17.9999 4V12.1707C16.8348 12.5826 16 13.6938 16 15C16 16.3062 16.8348 17.4174 17.9999 17.8292V20ZM19 14C18.4477 14 18 14.4477 18 15C18 15.5523 18.4477 16 19 16C19.5523 16 20 15.5523 20 15C20 14.4477 19.5523 14 19 14Z" fill="currentColor"/>
@@ -27,14 +28,12 @@
     <button type="submit" class="btn btn-primary">Ieškoti</button>
   </div>
 
-  <input type="checkbox" id="searchNustatymaiToggle" hidden <% if (usedHiddenFields) { %>checked<% } %>>
-
-  <div id="searchNustatymai" class="search-filters">
+  <div id="searchNustatymai" class="search-filters" aria-hidden="<% if (!usedHiddenFields) { %>true<% } else { %>false<% } %>" <% if (!usedHiddenFields) { %>inert<% } %>>
     <div class="search-filters-inner">
       <div class="search-filters-grid">
 
-        <div class="filter-group">
-          <div class="filter-group-label">Failas</div>
+        <fieldset class="filter-group">
+          <legend class="filter-group-label">Failas</legend>
           <%- include('../inputs/text', { label: 'Extension', name: 'extension', placeholder: 'Visi', values }) %>
           <%- include('../inputs/text', { label: 'MD5', name: 'md5', placeholder: 'd41d8cd98...', values }) %>
           <div class="form-group">
@@ -49,29 +48,50 @@
               <option value="archive" <%= values["saltinis"] == "archive" ? 'selected' : '' %>>Failas archyvo viduje</option>
             </select>
           </div>
-        </div>
+        </fieldset>
 
-        <div class="filter-group" style="justify-content: start;">
-          <div class="filter-group-label">Puslapių skaičius</div>
+        <fieldset class="filter-group justify-start">
+          <legend class="filter-group-label">Puslapių skaičius</legend>
           <%- include('../inputs/text', { label: 'Nuo', name: 'puslapiaiMin', placeholder: '0', values }) %>
           <%- include('../inputs/text', { label: 'Iki', name: 'puslapiaiMax', placeholder: '∞', values }) %>
-        </div>
+        </fieldset>
 
-        <div class="filter-group" style="grid-column: span 2; align-items: start; justify-content: start;">
-          <div class="filter-group-label">Turinys</div>
-          <div class="search-filters-grid" style="grid-template-columns: repeat(3, 1fr); width: fit-content;">            <%- include('../inputs/text', { label: 'Tel. numeris', name: 'telefonas', placeholder: '+37060000000', values }) %>
+        <fieldset class="filter-group col-span-2 max-sm:col-span-1 items-start justify-start">
+          <legend class="filter-group-label">Turinys</legend>
+          <div class="search-filters-grid grid-cols-3 w-fit gap-3 [&_.form-group]:mb-0 max-sm:grid-cols-2">
+            <%- include('../inputs/text', { label: 'Tel. numeris', name: 'telefonas', placeholder: '+37060000000', values }) %>
             <%- include('../inputs/text', { label: 'El. paštas', name: 'email', placeholder: 'viespirkiai@viespirkiai.org', values }) %>
             <%- include('../inputs/text', { label: 'Domenas', name: 'domain', placeholder: 'viespirkiai.org', values }) %>
             <%- include('../inputs/text', { label: 'IBAN numeris', name: 'iban', placeholder: 'LT0000000000...', values }) %>
             <%- include('../inputs/text', { label: 'JAR kodas', name: 'jarKodas', placeholder: '000000000', values }) %>
           </div>
-        </div>
+        </fieldset>
 
       </div>
     </div>
   </div>
 
   <script>
+    // Update aria-expanded and inert when checkbox changes
+    const searchToggle = document.querySelector('label[aria-controls="searchNustatymai"]');
+    const filterBox = document.getElementById('searchNustatymai');
+    const checkbox = document.getElementById('searchNustatymaiToggle');
+
+    checkbox.addEventListener('change', function() {
+      const isChecked = this.checked;
+      searchToggle.setAttribute('aria-expanded', isChecked);
+      searchToggle.setAttribute('aria-label', isChecked ? 'Slėpti filtrus' : 'Rodyti filtrus');
+      if (isChecked) {
+        filterBox.removeAttribute('inert');
+        filterBox.setAttribute('aria-hidden', 'false');
+        const firstInput = filterBox.querySelector('input, select');
+        if (firstInput) firstInput.focus();
+      } else {
+        filterBox.setAttribute('inert', '');
+        filterBox.setAttribute('aria-hidden', 'true');
+      }
+    });
+
     document.getElementById('search').addEventListener('keydown', function(e) {
       if (e.key === 'Enter') {
         e.preventDefault();

--- a/views/inputs/sort.ejs
+++ b/views/inputs/sort.ejs
@@ -1,5 +1,6 @@
-<button type="button" id="<%= name %>_btn" class="btn btn-form sort-toggle-btn" style="border-left: none; border-radius: 0 var(--radius-md) var(--radius-md) 0;">
-  <svg class="sort-icon" width="16" height="16" viewBox="0 0 24 24">
+<% const _sortDirLabel = values['sortDir'] === 'asc' ? 'Rikiavimo kryptis: nuo mažiausio' : 'Rikiavimo kryptis: nuo didžiausio'; %>
+<button type="button" id="<%= name %>_btn" class="btn btn-form sort-toggle-btn" style="border-left: none; border-radius: 0 var(--radius-md) var(--radius-md) 0;" aria-label="<%= _sortDirLabel %>" title="<%= _sortDirLabel %>">
+  <svg class="sort-icon" width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
     <path d="M3 18h6v-2H3v2zm0-5h12v-2H3v2zm0-5h18V6H3v2z" fill="currentColor"/>
   </svg>
 </button>
@@ -12,6 +13,9 @@
   let dir = input.value || "";
   function update() {
     icon.style.transform = dir === "asc" ? "scaleY(-1)" : "scaleY(1)";
+    const label = dir === "asc" ? "Rikiavimo kryptis: nuo mažiausio" : "Rikiavimo kryptis: nuo didžiausio";
+    btn.setAttribute('aria-label', label);
+    btn.setAttribute('title', label);
   }
   update();
   btn.addEventListener('click', () => {

--- a/views/sutartys/search.ejs
+++ b/views/sutartys/search.ejs
@@ -16,7 +16,8 @@
       enterkeyhint="search"
     />
 
-    <label for="searchNustatymaiToggle" class="btn btn-ghost btn-icon" title="Filtrai" aria-label="Rodyti filtrus">
+    <label class="btn btn-ghost btn-icon" title="Filtrai" aria-label="<%= usedHiddenFields ? 'Slėpti filtrus' : 'Rodyti filtrus' %>" aria-expanded="<%= usedHiddenFields ? 'true' : 'false' %>" aria-controls="searchNustatymai">
+      <input type="checkbox" id="searchNustatymaiToggle" class="sr-only" <% if (usedHiddenFields) { %>checked<% } %>>
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path fill-rule="evenodd" clip-rule="evenodd" d="M11.9999 3C11.4476 3 10.9999 3.44772 10.9999 4V6.17072C9.83476 6.58259 9 7.6938 9 8.99998C9 10.3062 9.83476 11.4174 10.9999 11.8292L10.9999 20C10.9999 20.5523 11.4476 21 11.9999 21C12.5522 21 12.9999 20.5523 12.9999 20V11.8293C14.1651 11.4175 15 10.3062 15 8.99998C15 7.69373 14.1651 6.58246 12.9999 6.17066V4C12.9999 3.44772 12.5522 3 11.9999 3ZM12 7.99998C11.4477 7.99998 11 8.4477 11 8.99998C11 9.55227 11.4477 9.99998 12 9.99998C12.5523 9.99998 13 9.55227 13 8.99998C13 8.4477 12.5523 7.99998 12 7.99998Z" fill="currentColor"/>
         <path fill-rule="evenodd" clip-rule="evenodd" d="M17.9999 20C17.9999 20.5523 18.4476 21 18.9999 21C19.5522 21 19.9999 20.5523 19.9999 20V17.8293C21.1651 17.4175 22 16.3062 22 15C22 13.6937 21.1651 12.5825 19.9999 12.1707V4C19.9999 3.44772 19.5522 3 18.9999 3C18.4476 3 17.9999 3.44772 17.9999 4V12.1707C16.8348 12.5826 16 13.6938 16 15C16 16.3062 16.8348 17.4174 17.9999 17.8292V20ZM19 14C18.4477 14 18 14.4477 18 15C18 15.5523 18.4477 16 19 16C19.5523 16 20 15.5523 20 15C20 14.4477 19.5523 14 19 14Z" fill="currentColor"/>
@@ -27,32 +28,30 @@
     <button type="submit" class="btn btn-primary">Ieškoti</button>
   </div>
 
-  <input type="checkbox" id="searchNustatymaiToggle" hidden <% if (usedHiddenFields) { %>checked<% } %>>
-
-  <div id="searchNustatymai" class="search-filters">
+  <div id="searchNustatymai" class="search-filters" aria-hidden="<% if (!usedHiddenFields) { %>true<% } else { %>false<% } %>" <% if (!usedHiddenFields) { %>inert<% } %>>
       <div class="search-filters-inner">
         <div class="search-filters-grid">
 
-          <div class="filter-group">
-            <div class="filter-group-label">Dalyviai</div>
+          <fieldset class="filter-group">
+            <legend class="filter-group-label">Dalyviai</legend>
             <%- include('../inputs/text', { label: 'Pirkėjo kodas', name: 'perkanciosiosOrganizacijosKodas', placeholder: 'Nenurodyta', values }) %>
             <%- include('../inputs/text', { label: 'Tiekėjo kodas', name: 'tiekejoKodas', placeholder: 'Nenurodyta', values }) %>
-          </div>
+          </fieldset>
 
-          <div class="filter-group">
-            <div class="filter-group-label">Laikotarpis</div>
+          <fieldset class="filter-group">
+            <legend class="filter-group-label">Laikotarpis</legend>
             <%- include('../inputs/date', { label: 'Sudaryta nuo', name: 'sudarymoDataNuo', values }) %>
             <%- include('../inputs/date', { label: 'Sudaryta iki', name: 'sudarymoDataIki', values }) %>
-          </div>
+          </fieldset>
 
-          <div class="filter-group">
-            <div class="filter-group-label">Vertė</div>
+          <fieldset class="filter-group">
+            <legend class="filter-group-label">Vertė</legend>
             <%- include('../inputs/number', { label: 'Vertė nuo', name: 'verteNuo', placeholder: '0 €', values }) %>
             <%- include('../inputs/number', { label: 'Vertė iki', name: 'verteIki', placeholder: '∞ €', values }) %>
-          </div>
+          </fieldset>
 
-          <div class="filter-group">
-            <div class="filter-group-label">Klasifikacija</div>
+          <fieldset class="filter-group">
+            <legend class="filter-group-label">Klasifikacija</legend>
             <div class="form-group">
               <label class="form-label flex justify-between" for="bvpzPrefiksas">
                 <span>BVPŽ prefiksas <sup>1</sup></span>
@@ -70,17 +69,17 @@
             <div class="form-group">
               <input type="text" class="form-control" name="bvpzPrefiksasKitas" id="bvpzPrefiksasKitas" value="<%= values["bvpzPrefiksasKitas"] || "" %>" placeholder="Nenurodyta"/>
             </div>
-          </div>
+          </fieldset>
 
-          <div class="filter-group">
-            <div class="filter-group-label">Identifikatoriai</div>
+          <fieldset class="filter-group">
+            <legend class="filter-group-label">Identifikatoriai</legend>
             <%- include('../inputs/number', { label: 'Unikalus ID', name: 'sutartiesUnikalusID', placeholder: 'Nenurodyta', values }) %>
             <%- include('../inputs/text', { label: 'Sut. numeris', name: 'sutartiesNumeris', placeholder: 'Nenurodyta', values }) %>
             <%- include('../inputs/text', { label: 'Pirkimo numeris', name: 'pirkimoNumeris', placeholder: 'Nenurodyta', values }) %>
-          </div>
+          </fieldset>
 
-          <div class="filter-group" style="justify-content: start;">
-            <div class="filter-group-label">Rikiavimas</div>
+          <fieldset class="filter-group justify-start">
+            <legend class="filter-group-label">Rikiavimas</legend>
             <div class="form-group">
               <label class="form-label" for="sort">Rikiuoti pagal</label>
               <div class="input-group">
@@ -99,13 +98,13 @@
                 <%- include('../inputs/sort', { label: '', name: 'sortDir', values }) %>
               </div>
             </div>
-          </div>
+          </fieldset>
 
-          <div class="filter-group" style="justify-content: start;">
-            <div class="filter-group-label">Filtrai</div>
+          <fieldset class="filter-group justify-start">
+            <legend class="filter-group-label">Filtrai</legend>
             <%- include('../inputs/checkbox', { name: 'tikSuDokumentais', label: "Tik su dokumentais", values }) %>
             <%- include('../inputs/checkbox', { name: 'ignoruotiSp', label: "Nerodyti pakeitimų (SP)", values }) %>
-          </div>
+          </fieldset>
 
         </div>
         <p class="text-muted text-xs mt-5"><sup>1</sup> Veikia tik ne tekstinėse paieškose</p>
@@ -113,6 +112,26 @@
   </div>
 
   <script>
+    // Update aria-expanded and inert when checkbox changes
+    const searchToggle = document.querySelector('label[aria-controls="searchNustatymai"]');
+    const filterBox = document.getElementById('searchNustatymai');
+    const checkbox = document.getElementById('searchNustatymaiToggle');
+
+    checkbox.addEventListener('change', function() {
+      const isChecked = this.checked;
+      searchToggle.setAttribute('aria-expanded', isChecked);
+      searchToggle.setAttribute('aria-label', isChecked ? 'Slėpti filtrus' : 'Rodyti filtrus');
+      if (isChecked) {
+        filterBox.removeAttribute('inert');
+        filterBox.setAttribute('aria-hidden', 'false');
+        const firstInput = filterBox.querySelector('input, select');
+        if (firstInput) firstInput.focus();
+      } else {
+        filterBox.setAttribute('inert', '');
+        filterBox.setAttribute('aria-hidden', 'true');
+      }
+    });
+
     document.getElementById('search').addEventListener('keydown', function(e) {
       if (e.key === 'Enter') {
         e.preventDefault();

--- a/views/viesiejiPirkimai/search.ejs
+++ b/views/viesiejiPirkimai/search.ejs
@@ -16,7 +16,8 @@
       enterkeyhint="search"
     />
 
-    <label for="searchNustatymaiToggle" class="btn btn-ghost btn-icon" title="Filtrai" aria-label="Rodyti filtrus">
+    <label class="btn btn-ghost btn-icon" title="Filtrai" aria-label="<%= usedHiddenFields ? 'Slėpti filtrus' : 'Rodyti filtrus' %>" aria-expanded="<%= usedHiddenFields ? 'true' : 'false' %>" aria-controls="searchNustatymai">
+      <input type="checkbox" id="searchNustatymaiToggle" class="sr-only" <% if (usedHiddenFields) { %>checked<% } %>>
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path fill-rule="evenodd" clip-rule="evenodd" d="M11.9999 3C11.4476 3 10.9999 3.44772 10.9999 4V6.17072C9.83476 6.58259 9 7.6938 9 8.99998C9 10.3062 9.83476 11.4174 10.9999 11.8292L10.9999 20C10.9999 20.5523 11.4476 21 11.9999 21C12.5522 21 12.9999 20.5523 12.9999 20V11.8293C14.1651 11.4175 15 10.3062 15 8.99998C15 7.69373 14.1651 6.58246 12.9999 6.17066V4C12.9999 3.44772 12.5522 3 11.9999 3ZM12 7.99998C11.4477 7.99998 11 8.4477 11 8.99998C11 9.55227 11.4477 9.99998 12 9.99998C12.5523 9.99998 13 9.55227 13 8.99998C13 8.4477 12.5523 7.99998 12 7.99998Z" fill="currentColor"/>
         <path fill-rule="evenodd" clip-rule="evenodd" d="M17.9999 20C17.9999 20.5523 18.4476 21 18.9999 21C19.5522 21 19.9999 20.5523 19.9999 20V17.8293C21.1651 17.4175 22 16.3062 22 15C22 13.6937 21.1651 12.5825 19.9999 12.1707V4C19.9999 3.44772 19.5522 3 18.9999 3C18.4476 3 17.9999 3.44772 17.9999 4V12.1707C16.8348 12.5826 16 13.6938 16 15C16 16.3062 16.8348 17.4174 17.9999 17.8292V20ZM19 14C18.4477 14 18 14.4477 18 15C18 15.5523 18.4477 16 19 16C19.5523 16 20 15.5523 20 15C20 14.4477 19.5523 14 19 14Z" fill="currentColor"/>
@@ -27,38 +28,36 @@
     <button type="submit" class="btn btn-primary">Ieškoti</button>
   </div>
 
-  <input type="checkbox" id="searchNustatymaiToggle" hidden <% if (usedHiddenFields) { %>checked<% } %>>
-
-  <div id="searchNustatymai" class="search-filters">
+  <div id="searchNustatymai" class="search-filters" aria-hidden="<% if (!usedHiddenFields) { %>true<% } else { %>false<% } %>" <% if (!usedHiddenFields) { %>inert<% } %>>
     <div class="search-filters-inner">
       <div class="search-filters-grid">
 
-        <div class="filter-group">
-          <div class="filter-group-label">Pirkimas</div>
+        <fieldset class="filter-group">
+          <legend class="filter-group-label">Pirkimas</legend>
           <%- include('../inputs/text', { label: 'Vykdytojo kodas', name: 'pvJarKodas', placeholder: 'Nenurodyta', values }) %>
           <%- include('../inputs/text', { label: 'Pirkimo ID', name: 'pirkimoId', placeholder: 'Nenurodyta', values }) %>
-        </div>
+        </fieldset>
 
-        <div class="filter-group">
-          <div class="filter-group-label">Paskelbimo data</div>
+        <fieldset class="filter-group">
+          <legend class="filter-group-label">Paskelbimo data</legend>
           <%- include('../inputs/date', { label: 'Paskelbta nuo', name: 'paskelbimoDataNuo', values }) %>
           <%- include('../inputs/date', { label: 'Paskelbta iki', name: 'paskelbimoDataIki', values }) %>
-        </div>
+        </fieldset>
 
-        <div class="filter-group">
-          <div class="filter-group-label">Pasiūlymų terminas</div>
+        <fieldset class="filter-group">
+          <legend class="filter-group-label">Pasiūlymų terminas</legend>
           <%- include('../inputs/date', { label: 'Terminas nuo', name: 'pasiulymuTerminasNuo', values }) %>
           <%- include('../inputs/date', { label: 'Terminas iki', name: 'pasiulymuTerminasIki', values }) %>
-        </div>
+        </fieldset>
 
-        <div class="filter-group">
-          <div class="filter-group-label">Numatoma vertė</div>
+        <fieldset class="filter-group">
+          <legend class="filter-group-label">Numatoma vertė</legend>
           <%- include('../inputs/number', { label: 'Numatoma vertė nuo', name: 'verteNuo', placeholder: '0 €', values }) %>
           <%- include('../inputs/number', { label: 'Numatoma vertė iki', name: 'verteIki', placeholder: '∞ €', values }) %>
-        </div>
+        </fieldset>
 
-        <div class="filter-group">
-          <div class="filter-group-label">Klasifikacija</div>
+        <fieldset class="filter-group">
+          <legend class="filter-group-label">Klasifikacija</legend>
           <div class="form-group">
             <label class="form-label" for="pirkimoBudas">Pirkimo būdas</label>
             <select name="pirkimoBudas" id="pirkimoBudas" class="form-control">
@@ -77,10 +76,10 @@
               <% }) %>
             </select>
           </div>
-        </div>
+        </fieldset>
 
-        <div class="filter-group justify-start">
-          <div class="filter-group-label">Rikiavimas</div>
+        <fieldset class="filter-group justify-start">
+          <legend class="filter-group-label">Rikiavimas</legend>
           <div class="form-group">
             <label class="form-label" for="sort">Rikiuoti pagal</label>
             <div class="input-group">
@@ -97,21 +96,41 @@
               <%- include('../inputs/sort', { label: '', name: 'sortDir', values }) %>
             </div>
           </div>
-        </div>
+        </fieldset>
 
-        <div class="filter-group justify-start">
-            <div class="filter-group-label">Kodai</div>
+        <fieldset class="filter-group justify-start">
+            <legend class="filter-group-label">Kodai</legend>
             <div>
                 <%- include('../inputs/text', { label: 'BVPŽ prefiksai', name: 'bvpzPrefiksai', placeholder: 'Visi', values }) %>
                 <a href="/bvpz" class="text-sm">Žr. BVPŽ</a>
             </div>
-        </div>
+        </fieldset>
 
       </div>
     </div>
   </div>
 
   <script>
+    // Update aria-expanded and inert when checkbox changes
+    const searchToggle = document.querySelector('label[aria-controls="searchNustatymai"]');
+    const filterBox = document.getElementById('searchNustatymai');
+    const checkbox = document.getElementById('searchNustatymaiToggle');
+
+    checkbox.addEventListener('change', function() {
+      const isChecked = this.checked;
+      searchToggle.setAttribute('aria-expanded', isChecked);
+      searchToggle.setAttribute('aria-label', isChecked ? 'Slėpti filtrus' : 'Rodyti filtrus');
+      if (isChecked) {
+        filterBox.removeAttribute('inert');
+        filterBox.setAttribute('aria-hidden', 'false');
+        const firstInput = filterBox.querySelector('input, select');
+        if (firstInput) firstInput.focus();
+      } else {
+        filterBox.setAttribute('inert', '');
+        filterBox.setAttribute('aria-hidden', 'true');
+      }
+    });
+
     document.getElementById('search').addEventListener('keydown', function(e) {
       if (e.key === 'Enter') {
         e.preventDefault();


### PR DESCRIPTION
Patvarkymai paieškos filtrams:

- filtrų įjungimas/išjungimas veikia su klaviatūra
- atsidarius susifokusuoja pirmas filtro pasirinkimas
- laukeliai sudėti į fieldgroups su legends, kad neregiams ir kitiems vartotojams būtų semantinės etikėtės
- pridėta kitų aria-labels
- čiut patvarkytas atvaizdavimas, ypač failų mobiliam, kad atrodytų vienodai per visas tris paieškas su filtrais

Papildomai:

- pataisytas vienas praleistas pre paieškos rezultatų atvaizdavime